### PR TITLE
Fix coverage report and add tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   - go test -v -race -covermode=atomic -coverprofile=coverage.out
 
 after_success:
-  - goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN
+  - goveralls -coverprofile=coverage.out -service=travis-ci

--- a/request_test.go
+++ b/request_test.go
@@ -94,6 +94,18 @@ func TestDecodeJSONErrorFromReadBytes(t *testing.T) {
 	st.Expect(t, u.Name, "")
 }
 
+func TestDecodeJSONEOF(t *testing.T) {
+	bodyBytes := []byte("")
+	strReader := bytes.NewBuffer(bodyBytes)
+	body := ioutil.NopCloser(strReader)
+	req := &http.Request{Header: http.Header{}, Body: body}
+	modifier := NewRequestModifier(req)
+	u := user{}
+	err := modifier.DecodeJSON(&u)
+	st.Expect(t, err, nil)
+	st.Expect(t, u.Name, "")
+}
+
 func TestDecodeJSONErrorFromDecode(t *testing.T) {
 	bodyBytes := []byte(`/`)
 	strReader := bytes.NewBuffer(bodyBytes)

--- a/request_test.go
+++ b/request_test.go
@@ -82,3 +82,13 @@ func TestDecodeJSON(t *testing.T) {
 	st.Expect(t, err, nil)
 	st.Expect(t, u.Name, "Rick")
 }
+
+func TestDecodeJSONErrorFromReadBytes(t *testing.T) {
+	body := ioutil.NopCloser(&errorReader{})
+	req := &http.Request{Header: http.Header{}, Body: body}
+	modifier := NewRequestModifier(req)
+	u := user{}
+	err := modifier.DecodeJSON(&u)
+	st.Expect(t, err, errRead)
+	st.Expect(t, u.Name, "")
+}

--- a/request_test.go
+++ b/request_test.go
@@ -1,10 +1,22 @@
 package intercept
 
 import (
+	"errors"
 	"github.com/nbio/st"
+	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 )
+
+var errRead = errors.New("read error")
+
+type errorReader struct {
+}
+
+func (r *errorReader) Read(p []byte) (int, error) {
+	return 0, errRead
+}
 
 func TestNewRequestModifier(t *testing.T) {
 	h := http.Header{}
@@ -13,4 +25,22 @@ func TestNewRequestModifier(t *testing.T) {
 	modifier := NewRequestModifier(req)
 	st.Expect(t, modifier.Request, req)
 	st.Expect(t, modifier.Header, h)
+}
+
+func TestReadString(t *testing.T) {
+	bodyStr := `{"hello":"bonjour"}`
+	strReader := strings.NewReader(bodyStr)
+	body := ioutil.NopCloser(strReader)
+	req := &http.Request{Header: http.Header{}, Body: body}
+	modifier := NewRequestModifier(req)
+	str, err := modifier.ReadString()
+	st.Expect(t, err, nil)
+	st.Expect(t, str, bodyStr)
+
+	body = ioutil.NopCloser(&errorReader{})
+	req = &http.Request{Header: http.Header{}, Body: body}
+	modifier = NewRequestModifier(req)
+	str, err = modifier.ReadString()
+	st.Expect(t, err, errRead)
+	st.Expect(t, str, "")
 }

--- a/request_test.go
+++ b/request_test.go
@@ -12,11 +12,14 @@ import (
 
 var errRead = errors.New("read error")
 
-type errorReader struct {
-}
+type errorReader struct{}
 
 func (r *errorReader) Read(p []byte) (int, error) {
 	return 0, errRead
+}
+
+type user struct {
+	Name string
 }
 
 func TestNewRequestModifier(t *testing.T) {
@@ -29,7 +32,7 @@ func TestNewRequestModifier(t *testing.T) {
 }
 
 func TestReadString(t *testing.T) {
-	bodyStr := `{"hello":"bonjour"}`
+	bodyStr := `{"name":"Rick"}`
 	strReader := strings.NewReader(bodyStr)
 	body := ioutil.NopCloser(strReader)
 	req := &http.Request{Header: http.Header{}, Body: body}
@@ -49,7 +52,7 @@ func TestReadStringError(t *testing.T) {
 }
 
 func TestReadBytes(t *testing.T) {
-	bodyBytes := []byte(`{"hello":"bonjour"}`)
+	bodyBytes := []byte(`{"name":"Rick"}`)
 	strReader := bytes.NewBuffer(bodyBytes)
 	body := ioutil.NopCloser(strReader)
 	req := &http.Request{Header: http.Header{}, Body: body}
@@ -66,4 +69,16 @@ func TestReadBytesError(t *testing.T) {
 	buf, err := modifier.ReadBytes()
 	st.Expect(t, err, errRead)
 	st.Expect(t, len(buf), 0)
+}
+
+func TestDecodeJSON(t *testing.T) {
+	bodyBytes := []byte(`{"name":"Rick"}`)
+	strReader := bytes.NewBuffer(bodyBytes)
+	body := ioutil.NopCloser(strReader)
+	req := &http.Request{Header: http.Header{}, Body: body}
+	modifier := NewRequestModifier(req)
+	u := user{}
+	err := modifier.DecodeJSON(&u)
+	st.Expect(t, err, nil)
+	st.Expect(t, u.Name, "Rick")
 }

--- a/request_test.go
+++ b/request_test.go
@@ -157,3 +157,15 @@ func TestDecodeXMLErrorFromDecode(t *testing.T) {
 	st.Expect(t, err.Error(), "XML syntax error on line 1: unescaped ]]> not in CDATA section")
 	st.Expect(t, u.Name, "")
 }
+
+func TestDecodeXMLEOF(t *testing.T) {
+	bodyBytes := []byte("")
+	strReader := bytes.NewBuffer(bodyBytes)
+	body := ioutil.NopCloser(strReader)
+	req := &http.Request{Header: http.Header{}, Body: body}
+	modifier := NewRequestModifier(req)
+	u := user{}
+	err := modifier.DecodeXML(&u, nil)
+	st.Expect(t, err, nil)
+	st.Expect(t, u.Name, "")
+}

--- a/request_test.go
+++ b/request_test.go
@@ -37,11 +37,13 @@ func TestReadString(t *testing.T) {
 	str, err := modifier.ReadString()
 	st.Expect(t, err, nil)
 	st.Expect(t, str, bodyStr)
+}
 
-	body = ioutil.NopCloser(&errorReader{})
-	req = &http.Request{Header: http.Header{}, Body: body}
-	modifier = NewRequestModifier(req)
-	str, err = modifier.ReadString()
+func TestReadStringError(t *testing.T) {
+	body := ioutil.NopCloser(&errorReader{})
+	req := &http.Request{Header: http.Header{}, Body: body}
+	modifier := NewRequestModifier(req)
+	str, err := modifier.ReadString()
 	st.Expect(t, err, errRead)
 	st.Expect(t, str, "")
 }
@@ -55,10 +57,12 @@ func TestReadBytes(t *testing.T) {
 	str, err := modifier.ReadBytes()
 	st.Expect(t, err, nil)
 	st.Expect(t, str, bodyBytes)
+}
 
-	body = ioutil.NopCloser(&errorReader{})
-	req = &http.Request{Header: http.Header{}, Body: body}
-	modifier = NewRequestModifier(req)
+func TestReadBytesError(t *testing.T) {
+	body := ioutil.NopCloser(&errorReader{})
+	req := &http.Request{Header: http.Header{}, Body: body}
+	modifier := NewRequestModifier(req)
 	buf, err := modifier.ReadBytes()
 	st.Expect(t, err, errRead)
 	st.Expect(t, len(buf), 0)

--- a/request_test.go
+++ b/request_test.go
@@ -143,3 +143,17 @@ func TestDecodeXMLErrorFromReadBytes(t *testing.T) {
 	st.Expect(t, err, errRead)
 	st.Expect(t, u.Name, "")
 }
+
+func TestDecodeXMLErrorFromDecode(t *testing.T) {
+	bodyBytes := []byte(`]]>`)
+	strReader := bytes.NewBuffer(bodyBytes)
+	body := ioutil.NopCloser(strReader)
+	req := &http.Request{Header: http.Header{}, Body: body}
+	modifier := NewRequestModifier(req)
+	u := user{}
+	err := modifier.DecodeXML(&u, nil)
+	_, ok := (err).(*xml.SyntaxError)
+	st.Expect(t, ok, true)
+	st.Expect(t, err.Error(), "XML syntax error on line 1: unescaped ]]> not in CDATA section")
+	st.Expect(t, u.Name, "")
+}

--- a/request_test.go
+++ b/request_test.go
@@ -1,6 +1,7 @@
 package intercept
 
 import (
+	"bytes"
 	"errors"
 	"github.com/nbio/st"
 	"io/ioutil"
@@ -43,4 +44,22 @@ func TestReadString(t *testing.T) {
 	str, err = modifier.ReadString()
 	st.Expect(t, err, errRead)
 	st.Expect(t, str, "")
+}
+
+func TestReadBytes(t *testing.T) {
+	bodyBytes := []byte(`{"hello":"bonjour"}`)
+	strReader := bytes.NewBuffer(bodyBytes)
+	body := ioutil.NopCloser(strReader)
+	req := &http.Request{Header: http.Header{}, Body: body}
+	modifier := NewRequestModifier(req)
+	str, err := modifier.ReadBytes()
+	st.Expect(t, err, nil)
+	st.Expect(t, str, bodyBytes)
+
+	body = ioutil.NopCloser(&errorReader{})
+	req = &http.Request{Header: http.Header{}, Body: body}
+	modifier = NewRequestModifier(req)
+	buf, err := modifier.ReadBytes()
+	st.Expect(t, err, errRead)
+	st.Expect(t, len(buf), 0)
 }

--- a/request_test.go
+++ b/request_test.go
@@ -133,3 +133,13 @@ func TestDecodeXML(t *testing.T) {
 	st.Expect(t, err, nil)
 	st.Expect(t, u.Name, "Rick")
 }
+
+func TestDecodeXMLErrorFromReadBytes(t *testing.T) {
+	body := ioutil.NopCloser(&errorReader{})
+	req := &http.Request{Header: http.Header{}, Body: body}
+	modifier := NewRequestModifier(req)
+	u := user{}
+	err := modifier.DecodeXML(&u, nil)
+	st.Expect(t, err, errRead)
+	st.Expect(t, u.Name, "")
+}

--- a/request_test.go
+++ b/request_test.go
@@ -2,6 +2,7 @@ package intercept
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"github.com/nbio/st"
 	"io/ioutil"
@@ -90,5 +91,19 @@ func TestDecodeJSONErrorFromReadBytes(t *testing.T) {
 	u := user{}
 	err := modifier.DecodeJSON(&u)
 	st.Expect(t, err, errRead)
+	st.Expect(t, u.Name, "")
+}
+
+func TestDecodeJSONErrorFromDecode(t *testing.T) {
+	bodyBytes := []byte(`/`)
+	strReader := bytes.NewBuffer(bodyBytes)
+	body := ioutil.NopCloser(strReader)
+	req := &http.Request{Header: http.Header{}, Body: body}
+	modifier := NewRequestModifier(req)
+	u := user{}
+	err := modifier.DecodeJSON(&u)
+	_, ok := (err).(*json.SyntaxError)
+	st.Expect(t, ok, true)
+	st.Expect(t, err.Error(), "invalid character '/' looking for beginning of value")
 	st.Expect(t, u.Name, "")
 }

--- a/request_test.go
+++ b/request_test.go
@@ -1,1 +1,16 @@
 package intercept
+
+import (
+	"github.com/nbio/st"
+	"net/http"
+	"testing"
+)
+
+func TestNewRequestModifier(t *testing.T) {
+	h := http.Header{}
+	h.Set("foo", "bar")
+	req := &http.Request{Header: h}
+	modifier := NewRequestModifier(req)
+	st.Expect(t, modifier.Request, req)
+	st.Expect(t, modifier.Header, h)
+}


### PR DESCRIPTION
Fix coverall test report by removing the token from the `.travis.yml` file. 3 tests were also added. I'll provide a few more tests in upcoming PRs.
