### PR TITLE
Add test for HandleHTTP

### DIFF
--- a/request.go
+++ b/request.go
@@ -182,11 +182,6 @@ func Request(h ReqModifierFunc) *RequestInterceptor {
 // HandleHTTP handles the middleware call chain, intercepting the request data if possible.
 // This methods implements the middleware layer compatible interface.
 func (s *RequestInterceptor) HandleHTTP(w http.ResponseWriter, r *http.Request, h http.Handler) {
-	if r.Method == "HEAD" || r.Method == "OPTIONS" {
-		h.ServeHTTP(w, r)
-		return
-	}
-
 	req := NewRequestModifier(r)
 	s.Modifier(req)
 	h.ServeHTTP(w, req.Request)

--- a/request_test.go
+++ b/request_test.go
@@ -351,14 +351,14 @@ func TestRequest(t *testing.T) {
 }
 
 func TestHandleHTTPHEADRequest(t *testing.T) {
-	testHandleHttpNotIntercepted(t, "HEAD")
+	testHandleHTTPNotIntercepted(t, "HEAD")
 }
 
 func TestHandleHTTPOPTIONSRequest(t *testing.T) {
-	testHandleHttpNotIntercepted(t, "OPTIONS")
+	testHandleHTTPNotIntercepted(t, "OPTIONS")
 }
 
-func testHandleHttpNotIntercepted(t *testing.T, method string) {
+func testHandleHTTPNotIntercepted(t *testing.T, method string) {
 	interceptor := Request(func(m *RequestModifier) {
 		m.Header.Set("foo", "bar")
 	})

--- a/request_test.go
+++ b/request_test.go
@@ -365,3 +365,18 @@ func TestHandleHTTPHEADRequest(t *testing.T) {
 	interceptor.HandleHTTP(w, req, handler)
 	st.Expect(t, string(w.Body), "Hi")
 }
+
+func TestHandleHTTPOPTIONSRequest(t *testing.T) {
+	modifierFunc := func(m *RequestModifier) {
+		m.Header.Set("foo", "bar")
+	}
+	w := utils.NewWriterStub()
+	req := &http.Request{Method: "OPTIONS", Header: make(http.Header)}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "Hi")
+		st.Expect(t, r.Header.Get("foo"), "")
+	})
+	interceptor := Request(modifierFunc)
+	interceptor.HandleHTTP(w, req, handler)
+	st.Expect(t, string(w.Body), "Hi")
+}

--- a/request_test.go
+++ b/request_test.go
@@ -350,27 +350,6 @@ func TestRequest(t *testing.T) {
 	st.Expect(t, intercepted, true)
 }
 
-func TestHandleHTTPHEADRequest(t *testing.T) {
-	testHandleHTTPNotIntercepted(t, "HEAD")
-}
-
-func TestHandleHTTPOPTIONSRequest(t *testing.T) {
-	testHandleHTTPNotIntercepted(t, "OPTIONS")
-}
-
-func testHandleHTTPNotIntercepted(t *testing.T, method string) {
-	interceptor := Request(func(m *RequestModifier) {
-		m.Header.Set("foo", "bar")
-	})
-	stubbedWriter := utils.NewWriterStub()
-	req := &http.Request{Method: method, Header: make(http.Header)}
-	handler := http.HandlerFunc(func(writer http.ResponseWriter, r *http.Request) {
-		st.Expect(t, writer, stubbedWriter)
-		st.Expect(t, r.Header.Get("foo"), "")
-	})
-	interceptor.HandleHTTP(stubbedWriter, req, handler)
-}
-
 func TestHandleHTTP(t *testing.T) {
 	interceptor := Request(func(m *RequestModifier) {
 		m.Header.Set("foo", "bar")

--- a/request_test.go
+++ b/request_test.go
@@ -352,31 +352,46 @@ func TestRequest(t *testing.T) {
 }
 
 func TestHandleHTTPHEADRequest(t *testing.T) {
-	modifierFunc := func(m *RequestModifier) {
-		m.Header.Set("foo", "bar")
-	}
-	w := utils.NewWriterStub()
-	req := &http.Request{Method: "HEAD", Header: make(http.Header)}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "Hi")
 		st.Expect(t, r.Header.Get("foo"), "")
 	})
-	interceptor := Request(modifierFunc)
+	interceptor := Request(func(m *RequestModifier) {
+		m.Header.Set("foo", "bar")
+	})
+	w := utils.NewWriterStub()
+	req := &http.Request{Method: "HEAD", Header: make(http.Header)}
 	interceptor.HandleHTTP(w, req, handler)
 	st.Expect(t, string(w.Body), "Hi")
 }
 
 func TestHandleHTTPOPTIONSRequest(t *testing.T) {
-	modifierFunc := func(m *RequestModifier) {
-		m.Header.Set("foo", "bar")
-	}
-	w := utils.NewWriterStub()
-	req := &http.Request{Method: "OPTIONS", Header: make(http.Header)}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, "Hi")
 		st.Expect(t, r.Header.Get("foo"), "")
 	})
-	interceptor := Request(modifierFunc)
+	interceptor := Request(func(m *RequestModifier) {
+		m.Header.Set("foo", "bar")
+	})
+	w := utils.NewWriterStub()
+	req := &http.Request{Method: "OPTIONS", Header: make(http.Header)}
+	interceptor.HandleHTTP(w, req, handler)
+	st.Expect(t, string(w.Body), "Hi")
+}
+
+func TestHandleHTTP(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "Hi")
+		st.Expect(t, r.Header.Get("foo"), "bar")
+		requestBody, _ := ioutil.ReadAll(r.Body)
+		st.Expect(t, string(requestBody), "Hello")
+	})
+	interceptor := Request(func(m *RequestModifier) {
+		m.Header.Set("foo", "bar")
+		m.String("Hello")
+	})
+	w := utils.NewWriterStub()
+	req := &http.Request{Method: "POST", Header: make(http.Header)}
 	interceptor.HandleHTTP(w, req, handler)
 	st.Expect(t, string(w.Body), "Hi")
 }


### PR DESCRIPTION
@h2non I'm not sure if these tests were properly handled. IMO it properly tests every part (writer, request, interception) of the method but there may be a cleaner/better way to do that. 

I'll start working on the filters for the request once this is merged.
