### PR TITLE
Fix ResponseModifier.Reader

### DIFF
--- a/response.go
+++ b/response.go
@@ -151,19 +151,19 @@ func (s *ResponseModifier) Reader(body io.Reader) error {
 		rc = ioutil.NopCloser(body)
 	}
 
-	req := s.Request
+	resp := s.Response
 	if body != nil {
 		switch v := body.(type) {
 		case *bytes.Buffer:
-			req.ContentLength = int64(v.Len())
+			resp.ContentLength = int64(v.Len())
 		case *bytes.Reader:
-			req.ContentLength = int64(v.Len())
+			resp.ContentLength = int64(v.Len())
 		case *strings.Reader:
-			req.ContentLength = int64(v.Len())
+			resp.ContentLength = int64(v.Len())
 		}
 	}
 
-	req.Body = rc
+	resp.Body = rc
 	return nil
 }
 

--- a/response_test.go
+++ b/response_test.go
@@ -198,3 +198,16 @@ func TestResponseModifierByte(t *testing.T) {
 	st.Expect(t, err, nil)
 	st.Expect(t, string(body), "Rick")
 }
+
+func TestResponseModifierJSONFromStruct(t *testing.T) {
+	req := &http.Request{}
+	resp := &http.Response{Header: http.Header{}}
+	modifier := NewResponseModifier(req, resp)
+	u := &user{Name: "Rick"}
+	modifier.JSON(u)
+	body, err := ioutil.ReadAll(resp.Body)
+	st.Expect(t, err, nil)
+	st.Expect(t, resp.ContentLength, int64(len(body)))
+	st.Expect(t, resp.Header.Get("Content-Type"), "application/json")
+	st.Expect(t, string(body), "{\"Name\":\"Rick\"}\n")
+}

--- a/response_test.go
+++ b/response_test.go
@@ -224,3 +224,16 @@ func TestResponseModifierJSONFromString(t *testing.T) {
 	st.Expect(t, resp.Header.Get("Content-Type"), "application/json")
 	st.Expect(t, string(body), input)
 }
+
+func TestResponseModifierJSONFromBytes(t *testing.T) {
+	req := &http.Request{}
+	resp := &http.Response{Header: http.Header{}}
+	modifier := NewResponseModifier(req, resp)
+	input := []byte(`{"Name":"Rick"}`)
+	modifier.JSON(input)
+	body, err := ioutil.ReadAll(resp.Body)
+	st.Expect(t, err, nil)
+	st.Expect(t, resp.ContentLength, int64(len(body)))
+	st.Expect(t, resp.Header.Get("Content-Type"), "application/json")
+	st.Expect(t, string(body), string(input))
+}

--- a/response_test.go
+++ b/response_test.go
@@ -211,3 +211,16 @@ func TestResponseModifierJSONFromStruct(t *testing.T) {
 	st.Expect(t, resp.Header.Get("Content-Type"), "application/json")
 	st.Expect(t, string(body), "{\"Name\":\"Rick\"}\n")
 }
+
+func TestResponseModifierJSONFromString(t *testing.T) {
+	req := &http.Request{}
+	resp := &http.Response{Header: http.Header{}}
+	modifier := NewResponseModifier(req, resp)
+	input := `{"Name":"Rick"}`
+	modifier.JSON(input)
+	body, err := ioutil.ReadAll(resp.Body)
+	st.Expect(t, err, nil)
+	st.Expect(t, resp.ContentLength, int64(len(body)))
+	st.Expect(t, resp.Header.Get("Content-Type"), "application/json")
+	st.Expect(t, string(body), input)
+}

--- a/response_test.go
+++ b/response_test.go
@@ -1,9 +1,11 @@
 package intercept
 
 import (
+	"bytes"
 	"encoding/json"
 	"encoding/xml"
 	"github.com/nbio/st"
+	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -275,4 +277,43 @@ func TestResponseModifierXMLFromBytes(t *testing.T) {
 	st.Expect(t, resp.ContentLength, int64(len(body)))
 	st.Expect(t, resp.Header.Get("Content-Type"), "application/xml")
 	st.Expect(t, string(body), string(input))
+}
+
+func TestResponseModifierReaderFromBytesBuffer(t *testing.T) {
+	req := &http.Request{}
+	resp := &http.Response{}
+	modifier := NewResponseModifier(req, resp)
+	reader := bytes.NewBuffer([]byte("Hello"))
+	err := modifier.Reader(reader)
+	st.Expect(t, err, nil)
+	_, ok := resp.Body.(io.ReadCloser)
+	st.Expect(t, ok, true)
+	body, _ := ioutil.ReadAll(resp.Body)
+	st.Expect(t, string(body), "Hello")
+}
+
+func TestResponseModifierReaderFromBytesReader(t *testing.T) {
+	req := &http.Request{}
+	resp := &http.Response{}
+	modifier := NewResponseModifier(req, resp)
+	reader := bytes.NewReader([]byte("Hello"))
+	err := modifier.Reader(reader)
+	st.Expect(t, err, nil)
+	_, ok := resp.Body.(io.ReadCloser)
+	st.Expect(t, ok, true)
+	body, _ := ioutil.ReadAll(resp.Body)
+	st.Expect(t, string(body), "Hello")
+}
+
+func TestResponseModifierReaderFromStringReader(t *testing.T) {
+	req := &http.Request{}
+	resp := &http.Response{}
+	modifier := NewResponseModifier(req, resp)
+	reader := strings.NewReader("Hello")
+	err := modifier.Reader(reader)
+	st.Expect(t, err, nil)
+	_, ok := resp.Body.(io.ReadCloser)
+	st.Expect(t, ok, true)
+	body, _ := ioutil.ReadAll(resp.Body)
+	st.Expect(t, string(body), "Hello")
 }

--- a/response_test.go
+++ b/response_test.go
@@ -237,3 +237,42 @@ func TestResponseModifierJSONFromBytes(t *testing.T) {
 	st.Expect(t, resp.Header.Get("Content-Type"), "application/json")
 	st.Expect(t, string(body), string(input))
 }
+
+func TestResponseModifierXMLFromStruct(t *testing.T) {
+	req := &http.Request{}
+	resp := &http.Response{Header: http.Header{}}
+	modifier := NewResponseModifier(req, resp)
+	u := &user{Name: "Rick"}
+	modifier.XML(u)
+	body, err := ioutil.ReadAll(resp.Body)
+	st.Expect(t, err, nil)
+	st.Expect(t, resp.ContentLength, int64(len(body)))
+	st.Expect(t, resp.Header.Get("Content-Type"), "application/xml")
+	st.Expect(t, string(body), "<Person><Name>Rick</Name></Person>")
+}
+
+func TestResponseModifierXMLFromString(t *testing.T) {
+	req := &http.Request{}
+	resp := &http.Response{Header: http.Header{}}
+	modifier := NewResponseModifier(req, resp)
+	input := `<Person><Name>Rick</Name></Person>`
+	modifier.XML(input)
+	body, err := ioutil.ReadAll(resp.Body)
+	st.Expect(t, err, nil)
+	st.Expect(t, resp.ContentLength, int64(len(body)))
+	st.Expect(t, resp.Header.Get("Content-Type"), "application/xml")
+	st.Expect(t, string(body), input)
+}
+
+func TestResponseModifierXMLFromBytes(t *testing.T) {
+	req := &http.Request{}
+	resp := &http.Response{Header: http.Header{}}
+	modifier := NewResponseModifier(req, resp)
+	input := []byte(`<Person><Name>Rick</Name></Person>`)
+	modifier.XML(input)
+	body, err := ioutil.ReadAll(resp.Body)
+	st.Expect(t, err, nil)
+	st.Expect(t, resp.ContentLength, int64(len(body)))
+	st.Expect(t, resp.Header.Get("Content-Type"), "application/xml")
+	st.Expect(t, string(body), string(input))
+}


### PR DESCRIPTION
If you check https://github.com/vinxi/intercept/blob/master/response.go#L154, you'll see that the `Reader` method modifies the request and not the response. This PR fixes it. Some extra tests were also added in previous commits.
